### PR TITLE
Added a method to integrate a 3D model as an input sphere mesh

### DIFF
--- a/Sources/RoboKit/Input Sphere/InputSphereManager Extensions/Entities Add-Remove Methods/Add Input Sphere.swift
+++ b/Sources/RoboKit/Input Sphere/InputSphereManager Extensions/Entities Add-Remove Methods/Add Input Sphere.swift
@@ -28,6 +28,8 @@ extension InputSphereManager {
     ///   - color: The color of the Input Sphere. Defaults to `.mint`.
     ///   - radius: The radius of the sphere. Defaults to `0.015`.
     ///   - showAxes: A Boolean value indicating whether to display Input Sphere's axes. Defaults to `true`.
+    ///   - modelEntity: An optional `Entity` to use
+    ///   instead of the default spherical mesh. If `nil`, a sphere is generated automatically.
     ///
     /// If the root point is `nil` or the Input Sphere has already been created,
     /// the method exits early and logs an error.
@@ -36,8 +38,9 @@ extension InputSphereManager {
         rootPoint: Entity?,
         color: Color = .mint,
         radius: Float = 0.015,
-        showAxes: Bool = true) {
-
+        modelEntity: Entity? = nil,
+        showAxes: Bool = true
+    ) {
         guard let rootPoint = rootPoint else {
             AppLogger.shared.error(
                 "Failed to create Input Sphere: Root Point is nil",
@@ -54,7 +57,7 @@ extension InputSphereManager {
             return
         }
 
-        let sphere = inputSphereEntity(color: color, radius: radius)
+        let sphere = inputSphereEntity(color: color, radius: radius, modelEntity: modelEntity)
         sphere.position = rootPoint.position + SIMD3<Float>(0, 0.3, 0)
         sphere.setOrientation(.init(), relativeTo: rootPoint)
         parentEntity.addChild(sphere)

--- a/Sources/RoboKit/Input Sphere/InputSphereManager Extensions/Entities Creation Methods/Input Sphere Entity.swift
+++ b/Sources/RoboKit/Input Sphere/InputSphereManager Extensions/Entities Creation Methods/Input Sphere Entity.swift
@@ -19,22 +19,36 @@ import RealityKit
 extension InputSphereManager {
     /// Creates an entity representing the Input Sphere with a 3D spherical model and input interaction components.
     ///
-    /// This method initializes a new `Entity` configured with a metallic material of the specified color,
-    /// a spherical mesh of the given radius, and essential RealityKit components to enable interaction,
-    /// including collision detection and hover effects.
-    ///
     /// - Parameters:
     ///   - color: The color applied to the sphere’s material.
     ///   - radius: The radius of the spherical mesh.
+    ///   - modelEntity: An optional `Entity` to use
+    ///   instead of the default spherical mesh. If `nil`, a sphere is generated automatically.
     ///
     /// - Returns: A fully configured `Entity` representing the Input Sphere.
-    internal func inputSphereEntity(color: Color, radius: Float) -> Entity {
+    internal func inputSphereEntity(
+        color: Color,
+        radius: Float,
+        modelEntity: Entity? = nil
+    ) -> Entity {
         logSphereCreationParameters(color: color, radius: radius)
 
         let entity = Entity()
-        setupModelComponent(for: entity, color: color, radius: radius)
-        setupInteractionComponents(for: entity, radius: radius)
-        logSuccessfulSphereCreation(color: color, radius: radius)
+        let entityRadius: Float
+
+        if let customEntity = modelEntity {
+            // Use the passed-in ModelComponent
+            entity.addChild(customEntity)
+            entityRadius = customEntity.visualBounds(relativeTo: nil).boundingRadius
+            logModelEntityParameters(modelEntity: customEntity)
+        } else {
+            // Fall back to generating a default sphere
+            setupSphereModelComponent(for: entity, color: color, radius: radius)
+            entityRadius = radius
+        }
+
+        setupInteractionComponents(for: entity, radius: entityRadius)
+        logSuccessfulSphereCreation(color: color, radius: entityRadius)
 
         return entity
     }
@@ -45,7 +59,7 @@ extension InputSphereManager {
     ///   - entity: The entity to configure.
     ///   - color: The color for the sphere's material.
     ///   - radius: The radius of the sphere.
-    private func setupModelComponent(for entity: Entity, color: Color, radius: Float) {
+    private func setupSphereModelComponent(for entity: Entity, color: Color, radius: Float) {
         let simpleMaterial = SimpleMaterial(
             color: UIColor(color), isMetallic: true
         )
@@ -96,6 +110,17 @@ extension InputSphereManager {
             context: [
                 "color": String(describing: color),
                 "radius": radius
+            ]
+        )
+    }
+
+    /// Logs parameters of the custom model entity
+    private func logModelEntityParameters(modelEntity: Entity) {
+        AppLogger.shared.debug(
+            "Applied Model Entity to the Input Sphere",
+            category: .inputsphere,
+            context: [
+                "Entity Name": modelEntity.name
             ]
         )
     }


### PR DESCRIPTION
This pull request enhances the `InputSphereManager` by introducing support for custom model entities when creating Input Sphere. The changes allow developers to specify a custom `Entity` instead of using the default spherical mesh, providing greater flexibility in visual and functional customization. Key updates include modifications to method signatures, logic for handling custom entities, and additional logging for debugging.

### Enhancements to Input Sphere creation:

* **Added support for custom model entities**: Updated the `addInputSphere` method to accept an optional `modelEntity` parameter. If provided, this entity is used instead of the default spherical mesh. [[1]](diffhunk://#diff-87163d94e383ce48c7b70e31274ba801aa40e131e04dbf03545b35e18167f32bR31-R32) [[2]](diffhunk://#diff-87163d94e383ce48c7b70e31274ba801aa40e131e04dbf03545b35e18167f32bL39-R43) [[3]](diffhunk://#diff-87163d94e383ce48c7b70e31274ba801aa40e131e04dbf03545b35e18167f32bL57-R60)

### Logging improvements:

* **Added logging for custom model entities**: Introduced the `logModelEntityParameters` method to debug and log details about the custom `modelEntity` used for Input Spheres.